### PR TITLE
fix: fix build on loong64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+numpy (1:1.24.2-2) unstable; urgency=medium
+
+  * Include architecture.mk, pkg-info.mk to fix build on loong64.
+  * The build previously fails with undefined DEB_HOST_ARCH.
+
+ -- Mingcong Bai <baimingcong@uniontech.com>  Mon, 27 May 2024 12:39:35 +0800
+
 numpy (1:1.24.2-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,8 @@
 #!/usr/bin/make -f
 
+include /usr/share/dpkg/architecture.mk
+include /usr/share/dpkg/pkg-info.mk
+
 export DH_VERBOSE=1
 
 PY3VERS=$(shell py3versions -vr)


### PR DESCRIPTION
- Include architecture.mk, pkg-info.mk to fix build on loong64.
- The build previously fails with undefined DEB_HOST_ARCH.